### PR TITLE
CSS classes "mySlides" need not have a number

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -53,8 +53,14 @@ function slideTheShow(direction, slideshowIndex) {
   // In our HTML file the slides have a class ending with a number of the slideshow, like ".mySlides2"
   // Neither slide nor card numbers are zero indexed,
   // so cardNumber is equal to slideshowIndex ("card1" corresponds to ".mySlides1" etc.)
-  const className = ".mySlides" + slideshowIndex;
-  const slides = document.querySelectorAll(className);
+  const nodeParent = 
+    document.querySelector(`#card${slideshowIndex}`);
+  const slides =
+     nodeParent.querySelectorAll("div[class^='mySlides']");
+
+  // const className = ".mySlides" + slideshowIndex;
+  // const slides = document.querySelectorAll(className);
+
   if (direction === 0) {
     console.log(`card ${slideshowIndex} has ${slides.length} slides`);
   }


### PR DESCRIPTION
this greatly simplified the web app since it is not important from this point on that the CSS class starting with mySlides have an index matching the container it is in (e.g. "#card1", "#card2", etc.)